### PR TITLE
Correct case of testRawImage.h

### DIFF
--- a/FingerJetFXOSE/libFRFXLL/samples/FRFXLLSample/frfxllLSample.c
+++ b/FingerJetFXOSE/libFRFXLL/samples/FRFXLLSample/frfxllLSample.c
@@ -38,7 +38,7 @@
 
 #include "testFeatures.h"
 #include "TestAnsiImage.h"
-#include "TestRawImage.h"
+#include "testRawImage.h"
 
 #include <inttypes.h>
 


### PR DESCRIPTION
Fixes build of target `frfxllSample` on case-sensitive file systems.