### PR TITLE
- fixed calls to TestGetLibraryVersion() and TestCreateContext()

### DIFF
--- a/FingerJetFXOSE/libFRFXLL/samples/FRFXLLSample/frfxllLSample.c
+++ b/FingerJetFXOSE/libFRFXLL/samples/FRFXLLSample/frfxllLSample.c
@@ -384,11 +384,11 @@ int RunTests() {
   _printf(("Starting tests.\n"));
   size = sizeof(data);  
   memset( data, 0, size);
-  TestGetLibraryVersion(data, &size);
+  TestGetLibraryVersion();
   _printf(("."));
   size = sizeof(data);  
   memset( data, 0, size);
-  TestCreateContext(data, &size);
+  TestCreateContext();
   _printf(("."));
   size = sizeof(data);  
   memset( data, 0, size);


### PR DESCRIPTION
The functions TestGetLibraryVersion() and TestCreateContext() do not take any parameter but have been called with parameters.
This produxed error when using a c23 compliant compiler.
see: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2432.pdf